### PR TITLE
Improve toast handling and Suno export generation

### DIFF
--- a/src/components/PrepForSuno.tsx
+++ b/src/components/PrepForSuno.tsx
@@ -23,10 +23,9 @@ export const PrepForSuno: React.FC<PrepForSunoProps> = ({
   onClose
 }) => {
   const [generatedPrompt, setGeneratedPrompt] = useState('');
-  const [isGenerating, setIsGenerating] = useState(false);
   const { toast } = useToast();
 
-  const generateStylePrompt = () => {
+  const generateStylePrompt = React.useCallback(() => {
     let stylePrompt = '';
     
     // Use existing musical context if available
@@ -80,9 +79,9 @@ export const PrepForSuno: React.FC<PrepForSunoProps> = ({
     }
     
     return stylePrompt;
-  };
+  }, [musicalContext, lyrics, userInput]);
 
-  const cleanLyrics = (rawLyrics: string) => {
+  const cleanLyrics = React.useCallback((rawLyrics: string) => {
     // Remove all markdown formatting, asterisks, commentary, and cleanup
     const cleaned = rawLyrics
       // Remove markdown formatting
@@ -150,19 +149,13 @@ export const PrepForSuno: React.FC<PrepForSunoProps> = ({
     }
     
     return cleaned;
-  };
+  }, []);
 
-  const generateSunoExport = () => {
+  const generateSunoExport = React.useCallback(() => {
     const stylePrompt = generateStylePrompt();
     const cleanedLyrics = cleanLyrics(lyrics);
-    
-    // Generate clean, Suno-ready format
-    const exportText = `${stylePrompt}
-
-${cleanedLyrics}`;
-    
-    setGeneratedPrompt(exportText);
-  };
+    setGeneratedPrompt(`${stylePrompt}\n\n${cleanedLyrics}`);
+  }, [generateStylePrompt, cleanLyrics, lyrics]);
 
   const copyToClipboard = async () => {
     try {
@@ -186,7 +179,7 @@ ${cleanedLyrics}`;
 
   React.useEffect(() => {
     generateSunoExport();
-  }, []);
+  }, [generateSunoExport]);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,8 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // Register listener once on mount
+  }, [])
 
   return {
     ...state,

--- a/tests/useToast.test.ts
+++ b/tests/useToast.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reducer } from '../src/hooks/use-toast';
+import type { ToastProps } from '../src/components/ui/toast';
+
+describe('useToast reducer', () => {
+  it('adds a toast', () => {
+    const state = reducer(
+      { toasts: [] },
+      {
+        type: 'ADD_TOAST',
+        toast: { id: '1', open: true } as ToastProps & { id: string }
+      }
+    );
+    expect(state.toasts).toHaveLength(1);
+  });
+
+  it('dismisses a toast', () => {
+    vi.useFakeTimers();
+    const state = reducer(
+      { toasts: [{ id: '1', open: true } as ToastProps & { id: string }] },
+      { type: 'DISMISS_TOAST', toastId: '1' }
+    );
+    expect(state.toasts[0]?.open).toBe(false);
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure toast hook registers listener only once
- refresh Suno export when lyrics or context change
- add reducer tests for toast notifications

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b78432c9a8832a80b8bba9f411cf03