### PR TITLE
Improve install prompt UX and add persistence tests

### DIFF
--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Download, X, Smartphone } from 'lucide-react';
+import { toast } from '@/components/ui/use-toast';
 
 // Change this value to control how often the prompt is shown.
 // 0 = every new session, 1 = daily, 7 = weekly, etc.
@@ -145,7 +146,10 @@ export const InstallPrompt: React.FC = () => {
       message += 'Look for "Add to Home screen", "Install app", or similar option in your browser menu.\n\nThis works best in Chrome, Edge, or Safari browsers.';
     }
     
-    alert(message);
+    toast({
+      title: 'Install App',
+      description: <div className="whitespace-pre-line">{message}</div>,
+    });
   };
 
   const handleDismiss = () => {

--- a/tests/persistence.test.ts
+++ b/tests/persistence.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadState, STATE_VERSION } from '../src/lib/state/persistence';
+
+// Polyfill a simple localStorage for the Node test environment
+const storage: Record<string, string> = {};
+const localStorageMock = {
+  getItem(key: string) {
+    return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null;
+  },
+  setItem(key: string, value: string) {
+    storage[key] = value;
+  },
+  removeItem(key: string) {
+    delete storage[key];
+  },
+  clear() {
+    for (const key of Object.keys(storage)) delete storage[key];
+  }
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, configurable: true });
+
+describe('loadState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns data when version matches', () => {
+    const payload = { v: STATE_VERSION, data: { foo: 'bar' } };
+    localStorage.setItem('cadence_state', JSON.stringify(payload));
+    expect(loadState<{ foo: string }>()).toEqual({ foo: 'bar' });
+  });
+
+  it('loads legacy unversioned data', () => {
+    const legacy = { foo: 'bar' };
+    localStorage.setItem('cadence_state', JSON.stringify(legacy));
+    expect(loadState<{ foo: string }>()).toEqual({ foo: 'bar' });
+  });
+
+  it('returns null for mismatched version', () => {
+    const payload = { v: STATE_VERSION + 1, data: { foo: 'bar' } };
+    localStorage.setItem('cadence_state', JSON.stringify(payload));
+    expect(loadState<{ foo: string }>()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- show manual install instructions in a toast instead of a blocking alert
- add unit tests for persistence state loader

## Testing
- `npm test`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68b78432c9a8832a80b8bba9f411cf03