### PR TITLE
Fix PWA installation when deployed under subpath

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,20 +14,20 @@
     <meta name="apple-mobile-web-app-title" content="Cadence Codex" />
     <meta name="mobile-web-app-capable" content="yes" />
     
-    <!-- Manifest -->
-    <link rel="manifest" href="/manifest.webmanifest" />
-    
-    <!-- Icons -->
-    <link rel="icon" href="/icon-192.png" type="image/png" />
-    <link rel="apple-touch-icon" href="/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="192x192" href="/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="512x512" href="/icon-512.png" />
+      <!-- Manifest -->
+      <link rel="manifest" href="./manifest.webmanifest" />
+
+      <!-- Icons -->
+      <link rel="icon" href="./icon-192.png" type="image/png" />
+      <link rel="apple-touch-icon" href="./icon-192.png" />
+      <link rel="apple-touch-icon" sizes="192x192" href="./icon-192.png" />
+      <link rel="apple-touch-icon" sizes="512x512" href="./icon-512.png" />
     
     <!-- Open Graph -->
     <meta property="og:title" content="Cadence Codex - AI Songwriting Assistant" />
     <meta property="og:description" content="Create professional lyrics with AI-powered guidance" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/icon-512.png" />
+      <meta property="og:image" content="./icon-512.png" />
     
     <!-- Additional PWA optimization -->
     <meta name="format-detection" content="telephone=no" />
@@ -37,8 +37,8 @@
   </head>
 
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+      <div id="root"></div>
+      <script type="module" src="./src/main.tsx"></script>
     
     <!-- Single Service Worker Registration -->
     <script>
@@ -46,9 +46,9 @@
         window.addEventListener('load', async () => {
           try {
             console.log('Registering service worker...');
-            const registration = await navigator.serviceWorker.register('/sw.js', {
-              scope: '/'
-            });
+              const registration = await navigator.serviceWorker.register('sw.js', {
+                scope: './'
+              });
             
             console.log('SW registered successfully:', registration);
             

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,50 +3,50 @@
   "name": "Cadence Codex - AI Songwriting Assistant",
   "short_name": "Cadence Codex",
   "description": "Create professional lyrics with AI-powered guidance through a structured 6-stage creative process",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#0D0004",
   "theme_color": "#C1001F",
-  "scope": "/",
-  "id": "/",
+  "scope": "./",
+  "id": "./",
   "categories": ["music", "productivity", "entertainment"],
   "lang": "en",
   "dir": "ltr",
   "prefer_related_applications": false,
   "icons": [
-    {
-      "src": "/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any maskable"
-    }
+      {
+        "src": "icon-192.png",
+        "sizes": "192x192",
+        "type": "image/png",
+        "purpose": "any maskable"
+      },
+      {
+        "src": "icon-512.png",
+        "sizes": "512x512",
+        "type": "image/png",
+        "purpose": "any maskable"
+      }
   ],
   "screenshots": [
-    {
-      "src": "/screenshot.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
+      {
+        "src": "screenshot.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      }
   ],
   "shortcuts": [
     {
       "name": "Start Writing",
       "short_name": "Write",
       "description": "Begin creating new lyrics",
-      "url": "/",
-      "icons": [
-        {
-          "src": "/icon-192.png",
-          "sizes": "192x192"
-        }
-      ]
+        "url": "./",
+        "icons": [
+          {
+            "src": "icon-192.png",
+            "sizes": "192x192"
+          }
+        ]
     }
   ],
   "launch_handler": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,17 +1,17 @@
 
-const CACHE_NAME = 'cadence-codex-v8';
+const CACHE_NAME = 'cadence-codex-v9';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest',
-  '/icon-192.png',
-  '/icon-512.png',
-  '/screenshot.png'
+  './',
+  './index.html',
+  './manifest.webmanifest',
+  './icon-192.png',
+  './icon-512.png',
+  './screenshot.png'
 ];
 
 // Install event - cache resources
 self.addEventListener('install', (event) => {
-  console.log('Service Worker: Installing v8');
+  console.log('Service Worker: Installing v9');
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then((cache) => {
@@ -30,7 +30,7 @@ self.addEventListener('install', (event) => {
 
 // Activate event - clean up old caches
 self.addEventListener('activate', (event) => {
-  console.log('Service Worker: Activating v8');
+  console.log('Service Worker: Activating v9');
   event.waitUntil(
     caches.keys().then((cacheNames) => {
       return Promise.all(
@@ -69,10 +69,10 @@ self.addEventListener('fetch', (event) => {
 
         return cachedResponse || fetchPromise;
       })
-    ).catch(() => {
-      if (event.request.destination === 'document') {
-        return caches.match('/');
-      }
-    })
+      ).catch(() => {
+        if (event.request.destination === 'document') {
+          return caches.match('./');
+        }
+      })
   );
 });


### PR DESCRIPTION
## Summary
- use relative paths for manifest, icons, and service worker registration so the app can be installed as a PWA from subdirectories
- update service worker caching strategy to use relative URLs and new cache version

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b787b72f4c832aadcf470830620b1e